### PR TITLE
Switch from comma to semicolon for arguments in HYPERLINK formula

### DIFF
--- a/OntologySearch.gs
+++ b/OntologySearch.gs
@@ -317,7 +317,7 @@ function handleTermInsertion(term_id) {
                 sheet.getRange(row, selectedColumn).setValue(ontologyObject.term);
                 sheet.getRange(row, nextColumn).setValue(ontologyObject.url);
             } else {
-                sheet.getRange(row, selectedColumn).setFormula('=HYPERLINK("' + ontologyObject.url + '","' + ontologyObject.term + '")')
+                sheet.getRange(row, selectedColumn).setFormula('=HYPERLINK("' + ontologyObject.url + '";"' + ontologyObject.term + '")')
             }
         }
     }

--- a/OntologyTagging.gs
+++ b/OntologyTagging.gs
@@ -184,7 +184,7 @@ function replaceTermWithSelectedValue(term_id) {
               sheet.getRange(row, selectedColumn).setValue(ontologyObject.term);
               sheet.getRange(row, nextColumn).setValue(ontologyObject.accession);
             } else {
-              sheet.getRange(row, selectedColumn).setFormula('=HYPERLINK("'+  ontologyObject.accession +'","' + ontologyObject.term + '")')
+              sheet.getRange(row, selectedColumn).setFormula('=HYPERLINK("'+  ontologyObject.accession +'";"' + ontologyObject.term + '")')
             }
                 }
             }


### PR DESCRIPTION
Hi, needs testing if this works in a, say, UK locale where the comma is default separator.
If not, the google script needs to determine what to use :-( 
closes #36