### PR TITLE
[WIP] Feature/custom ols3

### DIFF
--- a/Ontology-Search-Template.html
+++ b/Ontology-Search-Template.html
@@ -29,7 +29,7 @@
         .hidden {
             display: none;
         }
-        
+
         .error {
           padding-top: 10px;
           color: #e74c3c;
@@ -233,6 +233,7 @@
                         <option value="bioportal" selected>Search BioPortal</option>
                         <option value="lov">Search LOV</option>
                         <option value="ols">Search OLS</option>
+                        <option value="tib-ols">Search TIB TS</option>
                     </select>
                 </div>
 
@@ -302,21 +303,21 @@
          * the sidebar UI with the resulting translation.
          */
         function runSearch() {
-            
+
             var term = $('input[name=search-text]').val();
-            
+
             if(term === "") {
                 showError('Please enter a search term.', $('#button-bar'));
                 return
             }
-            
-            this.disabled = true;            
-            
+
+            this.disabled = true;
+
             $('#search-results').html('<div id="spinner"><img src="//s-media-cache-ak0.pinimg.com/originals/0a/59/71/0a59718a5ee79a0558930ca9907c0659.gif" width="70px"/><p>Searching...</p></div>');
             $('#error').remove();
 
             var service = $('#service').val();
-            
+
 
             google.script.run
                 .withSuccessHandler(
@@ -325,10 +326,10 @@
                         var html = '<div id="accordion" class="accordion">';
                         console.log(result);
                         if (result) {
-                        
+
                             Object.keys(result).sort().forEach(function(ontology_abbr) {
                                 var ontology = result[ontology_abbr];
-                                
+
                                 html += '<h3><span class="ontology-abbr">' + ontology_abbr + '</span> - <span class="ontology-name">' + ontology["ontology-name"] + '</span></h3>' +
                                     '<div><ul>'
 
@@ -345,10 +346,10 @@
                                         '<div class="clearfix"></div>' +
                                         '</li>';
                                 });
-                                
+
                                 html += '</ul></div>';
                             });
-                               
+
                         } else {
                             html += "<p>Sorry, no results were found matching your query...</p>";
                         }

--- a/Ontology-Search-Template.html
+++ b/Ontology-Search-Template.html
@@ -234,6 +234,7 @@
                         <option value="lov">Search LOV</option>
                         <option value="ols">Search OLS</option>
                         <option value="tib-ols">Search TIB TS</option>
+                        <option value="custom-ols3">Search custom OLS3</option>
                     </select>
                 </div>
 

--- a/OntologySearch.gs
+++ b/OntologySearch.gs
@@ -134,7 +134,7 @@ function searchLOV(term) {
         var restriction = findRestrictionForCurrentColumn("LOV");
         var vocabularies = getLinkedOpenVocabularies();
 
-        var url = "http://lov.okfn.org/dataset/lov/api/v2/search?q=" + term;
+        var url = "https://lov.linkeddata.es/dataset/lov/api/v2/search?q=" + term;
         var vocabShortname;
         var vocabURI;
         if (restriction.source) {
@@ -142,7 +142,7 @@ function searchLOV(term) {
             if (vocabularies[vocabShortname]) {
                 vocabURI = vocabularies[vocabShortname].uri;
                 if (vocabURI)
-                    url = "http://lov.okfn.org/dataset/lov/api/v2/search?q=" + term + "&voc=" + vocabURI;
+                    url = "https://lov.linkeddata.es/dataset/lov/api/v2/search?q=" + term + "&voc=" + vocabURI;
             } else {
                 url = "";
             }

--- a/OntologySearch.gs
+++ b/OntologySearch.gs
@@ -317,7 +317,7 @@ function handleTermInsertion(term_id) {
                 sheet.getRange(row, selectedColumn).setValue(ontologyObject.term);
                 sheet.getRange(row, nextColumn).setValue(ontologyObject.url);
             } else {
-                sheet.getRange(row, selectedColumn).setFormula('=HYPERLINK("' + ontologyObject.url + '","' + ontologyObject.term + '")')
+                sheet.getRange(row, selectedColumn).setFormula('=HYPERLINK("' + ontologyObject.url + '";"' + ontologyObject.term + '")')
             }
         }
     }

--- a/OntologySearch.gs
+++ b/OntologySearch.gs
@@ -54,6 +54,8 @@ function performSearch(service, term) {
       return searchOLS(term);
     case "tib-ols":
       return searchTIBOLS(term);
+    case "custom-ols3":
+      return searchCustomOLS3(term);
     default:
       return searchLOV(term);
   }
@@ -287,6 +289,63 @@ function searchTIBOLS(term) {
     var restriction = findRestrictionForCurrentColumn("OLS");
     var ontologies = getTIBOLSOntologies();
     var url = TIBOLS_API_BASE_URI + '/search';
+    var queryObj = {
+      q: term,
+      rows: OLS_PAGINATION_SIZE,
+      start: 0,
+      ontology: restriction ? restriction.ontologyId : undefined
+    };
+    var queryString = jsonToQueryString(queryObj);
+    url += '?' + queryString;
+    var cacheResult = fetchFromCache(url);
+    if (cacheResult) {
+      return JSON.parse(cacheResult);
+    }
+    var text = UrlFetchApp.fetch(url).getContentText(), json = JSON.parse(text), ontologyDict = {};
+
+    var docs = json.response && json.response.docs;
+    if (!docs || docs.length === 0) {
+      throw "No Result found.";
+    }
+    docs.forEach(function(elem) {
+      var ontology = ontologies[elem.ontology_name], ontologyLabel = elem.ontology_prefix, record;
+      if (!ontologyDict[ontologyLabel]) {
+        ontologyDict[ontologyLabel] = {"ontology-name": elem.ontology_name, "terms": []};
+        record = {
+          label: elem.label,
+          id: elem.short_form,
+          'ontology-label': elem.ontology_prefix,
+          'ontology-name': elem.ontology_name,
+          accession: elem.iri,//elem.obo_id,
+          ontology: elem.ontology_name,
+          details: '',
+          url: elem.iri
+        };
+
+        storeInCache(record.id, JSON.stringify(record));
+        ontologyDict[ontologyLabel].terms.push(record);
+      }
+    });
+    storeInCache(url, JSON.stringify(ontologyDict));
+    // Logger.log(ontologyDict);
+    return ontologyDict;
+  }
+  catch(e) {
+    Logger.log(e);
+    throw(e);
+  }
+}
+
+/**
+ * @method
+ * @name searchCustomOLS3
+ * @param{string} term
+ */
+function searchCustomOLS3(term) {
+  try {
+    var restriction = findRestrictionForCurrentColumn("OLS");
+    var ontologies = getCustomOLS3Ontologies();
+    var url = CUSTOMOLS3_API_BASE_URI + '/search';
     var queryObj = {
       q: term,
       rows: OLS_PAGINATION_SIZE,

--- a/OntologySearch.gs
+++ b/OntologySearch.gs
@@ -251,7 +251,7 @@ function searchOLS(term) {
         ontologyDict[ontologyLabel] = {"ontology-name": elem.ontology_name, "terms": []};
         record = {
           label: elem.label,
-          id: elem.id,
+          id: elem.short_form,
           'ontology-label': elem.ontology_prefix,
           'ontology-name': elem.ontology_name,
           accession: elem.iri,//elem.obo_id,
@@ -293,7 +293,7 @@ function handleTermInsertion(term_id) {
     // figure out whether the Term Source REF and Term Accession Number columns exist, if they do exist at all. Insertion technique will vary
     // depending on the file being looked at.
     var sourceAndAccessionPositions = getSourceAndAccessionPositionsForTerm(selectedRange.getColumn());
-    
+
     // add all terms into a separate sheet with all their information.
     if (sourceAndAccessionPositions.sourceRef != undefined && sourceAndAccessionPositions.accession != undefined) {
         insertOntologySourceInformationInInvestigationBlock(ontologyObject);

--- a/OntologyTagging.gs
+++ b/OntologyTagging.gs
@@ -184,7 +184,7 @@ function replaceTermWithSelectedValue(term_id) {
               sheet.getRange(row, selectedColumn).setValue(ontologyObject.term);
               sheet.getRange(row, nextColumn).setValue(ontologyObject.accession);
             } else {
-              sheet.getRange(row, selectedColumn).setFormula('=HYPERLINK("'+  ontologyObject.accession +'","' + ontologyObject.term + '")')
+              sheet.getRange(row, selectedColumn).setFormula('=HYPERLINK("'+  ontologyObject.accession +'";"' + ontologyObject.term + '")')
             }
                 }
             }

--- a/Ontomaton-terms.md
+++ b/Ontomaton-terms.md
@@ -13,6 +13,7 @@
 <li><a href="http://data.bioontology.org/documentation" rel="nofollow">NBCO Bioportal</a></li>
 <li><a href="https://www.ebi.ac.uk/ols/docs/api" rel="nofollow">EMBL-EBI Ontology Lookup Service</a></li>
 <li><a href="https://lov.linkeddata.es/dataset/lov/api" rel="nofollow">Linked Open Vocabularies catalogue</a></li>
+<li><a href="https://service.tib.eu/ts4tib/api" rel="nofollow">TIB Terminology Service</a></li>
 </ul>
 
 
@@ -30,11 +31,11 @@ Bioinformatics 2013 29: 525-527. <a href="https://doi.org/10.1093/bioinformatics
 
 ----
 
- 
+
 ### Video Tutorial
 
 Access the video tutorial showing how to install and use OntoMaton (version 1) [here](http://www.youtube.com/watch?v=Qs0nxGBfQac&feature=player_embedded).
- 
+
 ### Templates
 
 Templates can be found through accessing them on the google templates site. OntoMaton templates are [here](https://drive.google.com/templates?type=spreadsheets&q=ontomaton).

--- a/README.md
+++ b/README.md
@@ -20,22 +20,22 @@ OntoMaton facilitates ontology search and tagging functionalities within Google 
 ### Read the Publication...
 Access the Open Access <a href="http://bioinformatics.oxfordjournals.org">Bioinformatics</a> article on OntoMaton [here](http://dx.doi.org/10.1093/bioinformatics/bts718).
 
-<i>Eamonn Maguire, Alejandra González-Beltrán, Patricia L. Whetzel, Susanna-Assunta Sansone, and Philippe Rocca-Serra  
-OntoMaton: a Bioportal powered ontology widget for Google Spreadsheets  
+<i>Eamonn Maguire, Alejandra González-Beltrán, Patricia L. Whetzel, Susanna-Assunta Sansone, and Philippe Rocca-Serra
+OntoMaton: a Bioportal powered ontology widget for Google Spreadsheets
 Bioinformatics 2013 29: 525-527. doi: [10.1093/bioinformatics/bts718](http://dx.doi.org/10.1093/bioinformatics/bts718)</i>
 
 Please, note that at the time of the publication, OntoMaton was powered by the <a href="http://bioportal.bioontology.org/">NCBO BioPortal</a> web services. Since then, we have made the following extensions:
 
 - we upgraded the code to [Google Add-ons for Docs and Sheets](http://googledrive.blogspot.it/2014/03/add-ons.html), which [deprecated the Apps Script applications and the Script Gallery](http://googleappsdeveloper.blogspot.co.uk/2014/06/deprecating-script-gallery-in-old.html), used in the original OntoMaton version
 - we upgraded to the new BioPortal API for searching ontology terms and annotator services (see BioPortal 4.0 release notes), as the old API was deprecated in 2014
-- we extended the ontology search functionality to support REST services from the <a href="http://lov.okfn.org/">Linked Open Vocabularies</a> and the <a href="https://www.ebi.ac.uk/ols/">EBI Ontology Lookup Service</a>, thus now allowing ontology term searches over three separate services.
+- we extended the ontology search functionality to support REST services from the <a href="http://lov.okfn.org/">Linked Open Vocabularies</a>, the <a href="https://www.ebi.ac.uk/ols/">EBI Ontology Lookup Service</a>, and the <a href="https://service.tib.eu/ts4tib/api">TIB Terminology Service</a>, thus now allowing ontology term searches over three separate services.
 
-For more information, see [our blog posts on OntoMaton](https://isatools.wordpress.com/?s=ontomaton). 
+For more information, see [our blog posts on OntoMaton](https://isatools.wordpress.com/?s=ontomaton).
 
 
 ### Installation
 
-With the new add on infrastructure, installation is very easy. 
+With the new add on infrastructure, installation is very easy.
 
 1. Click on the 'Add-ons' menu item in your Google Spreadsheet:
 
@@ -43,7 +43,7 @@ With the new add on infrastructure, installation is very easy.
 <img src="https://github.com/ISA-tools/OntoMaton/blob/master/figures/ontomaton-fig1.png" width="500">
 </div>
 
-2.  Click on 'Get add-ons...' and then search for 'OntoMaton': 
+2.  Click on 'Get add-ons...' and then search for 'OntoMaton':
 
 <div align="center">
 <img src="https://github.com/ISA-tools/OntoMaton/blob/master/figures/ontomaton-fig2.png?" height="200">
@@ -68,7 +68,7 @@ Here you can click on the image and read more about OntoMaton:
 </div>
 
 
-4. You'll then have the OntoMaton app installed. 
+4. You'll then have the OntoMaton app installed.
 
 <div align="center">
 <img src="https://github.com/ISA-tools/OntoMaton/blob/master/figures/ontomaton-fig6.png" width="500">
@@ -90,7 +90,7 @@ From OntoMaton, you can search three different services within one tool: the [NC
 
 ### Ontology Tagging
 
-With OntoMaton, you can select a number of spreadsheet cells and then 'tag' them. This means that OntoMaton will take the terms in the cells and send them to BioPortal's Annotator service. The results will come back as a list of the free text terms, showing for each all matches in BioPortal. 
+With OntoMaton, you can select a number of spreadsheet cells and then 'tag' them. This means that OntoMaton will take the terms in the cells and send them to BioPortal's Annotator service. The results will come back as a list of the free text terms, showing for each all matches in BioPortal.
 
 <div align="center">
 <img src="https://isatools.files.wordpress.com/2014/04/screen-shot-2014-04-16-at-18-55-27.png?h=500"/>
@@ -105,8 +105,8 @@ With OntoMaton, you can select a number of spreadsheet cells and then 'tag' them
 
 From the settings screen, you can configure:
 
-* How terms should be inserted in to the spreadsheet when not in 'ISA mode' (where the next columns aren't named 'Term Source REF' or 'Term Source Accession'). The two options are as either as a hyperlink to the term in Bioportal/OLS/LOV or as a term name with the hyperlink in parentheses.  
-* Restrictions, which specify for zero or more columns (with a name in the first cell), restrictions that should be placed on the search space per each of the ontology lookup services we use (Bioportal/OLS/LOV) E.g. the column 'Label' is restricted to terms from the Chemincal Entities of Biomedical Interest ontology (ChEBI). Please, note that for instance if a column has a restriction over the BioPortal service, the restiction will not have an effect if searching terms with OLS. 
+* How terms should be inserted in to the spreadsheet when not in 'ISA mode' (where the next columns aren't named 'Term Source REF' or 'Term Source Accession'). The two options are as either as a hyperlink to the term in Bioportal/OLS/LOV or as a term name with the hyperlink in parentheses.
+* Restrictions, which specify for zero or more columns (with a name in the first cell), restrictions that should be placed on the search space per each of the ontology lookup services we use (Bioportal/OLS/LOV) E.g. the column 'Label' is restricted to terms from the Chemincal Entities of Biomedical Interest ontology (ChEBI). Please, note that for instance if a column has a restriction over the BioPortal service, the restiction will not have an effect if searching terms with OLS.
 
 
 ### Restricting OntoMaton's search space
@@ -121,17 +121,17 @@ From the settings screen, you can configure:
 
 
 When you add a restriction using the 'Settings' panel for the first time, a 'Restrictions' sheet will be added automatically. This sheet will have the following column headers:
-```Column Name | Ontology |	 Branch | Version | Ontology Name | Service```. Then you may define for a particular column header in your spreadsheet what ontology should be searched (or list of ontologies) over what service (BioPortal, OLS or LOV). A restriction will only apply if using the corresponding service for search. 
+```Column Name | Ontology |	 Branch | Version | Ontology Name | Service```. Then you may define for a particular column header in your spreadsheet what ontology should be searched (or list of ontologies) over what service (BioPortal, OLS or LOV). A restriction will only apply if using the corresponding service for search.
 
 Additionally, within one ontology restriction, for BioPortal searches, you can restrict to a particular branch of an ontology, providing a way to further restrict the search space.
 
 An example of a google spreadsheet with such functionality can be viewed here: https://docs.google.com/spreadsheet/ccc?key=0Al5WvYyk0zzmdDNLeEcxWHZJX042dS0taXJPNXpJMHc
 
- 
+
 ### Video Tutorial
 
 Access the video tutorial showing how to install and use OntoMaton (version 1) [here](http://www.youtube.com/watch?v=Qs0nxGBfQac&feature=player_embedded).
- 
+
 ### Templates
 
 Templates can be found through accessing them on the google templates site. OntoMaton templates are [here](https://drive.google.com/templates?type=spreadsheets&q=ontomaton).

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ From the settings screen, you can configure:
 
 * How terms should be inserted in to the spreadsheet when not in 'ISA mode' (where the next columns aren't named 'Term Source REF' or 'Term Source Accession'). The two options are as either as a hyperlink to the term in Bioportal/OLS/LOV or as a term name with the hyperlink in parentheses.
 * Restrictions, which specify for zero or more columns (with a name in the first cell), restrictions that should be placed on the search space per each of the ontology lookup services we use (Bioportal/OLS/LOV) E.g. the column 'Label' is restricted to terms from the Chemincal Entities of Biomedical Interest ontology (ChEBI). Please, note that for instance if a column has a restriction over the BioPortal service, the restiction will not have an effect if searching terms with OLS.
-
+* Setting a Custom API base URL for OLS3-compatible terminology services. 
 
 ### Restricting OntoMaton's search space
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Please, note that at the time of the publication, OntoMaton was powered by the <
 
 - we upgraded the code to [Google Add-ons for Docs and Sheets](http://googledrive.blogspot.it/2014/03/add-ons.html), which [deprecated the Apps Script applications and the Script Gallery](http://googleappsdeveloper.blogspot.co.uk/2014/06/deprecating-script-gallery-in-old.html), used in the original OntoMaton version
 - we upgraded to the new BioPortal API for searching ontology terms and annotator services (see BioPortal 4.0 release notes), as the old API was deprecated in 2014
-- we extended the ontology search functionality to support REST services from the <a href="http://lov.okfn.org/">Linked Open Vocabularies</a> and the <a href="https://www.ebi.ac.uk/ols/">EBI Ontology Lookup Service</a>, thus now allowing ontology term searches over three separate services.
+- we extended the ontology search functionality to support REST services from the <a href="https://lov.linkeddata.es/">Linked Open Vocabularies</a> and the <a href="https://www.ebi.ac.uk/ols/">EBI Ontology Lookup Service</a>, thus now allowing ontology term searches over three separate services.
 
 For more information, see [our blog posts on OntoMaton](https://isatools.wordpress.com/?s=ontomaton). 
 
@@ -82,7 +82,7 @@ You can access it through the 'Add On' menu option.
 
 ### Ontology Search
 
-From OntoMaton, you can search three different services within one tool: the [NCBO Bioportal](http://bioportal.bioontology.org/), [Linked Open Vocabularies](http://lov.okfn.org) and [EBI Ontology Lookup Service](https://www.ebi.ac.uk/ols/), and insert the terms in your Google Spreadsheet directly. Full term provenance is recorded for you and later downstream analysis.
+From OntoMaton, you can search three different services within one tool: the [NCBO Bioportal](http://bioportal.bioontology.org/), [Linked Open Vocabularies](https://lov.linkeddata.es) and [EBI Ontology Lookup Service](https://www.ebi.ac.uk/ols/), and insert the terms in your Google Spreadsheet directly. Full term provenance is recorded for you and later downstream analysis.
 
 <div align="center">
 <img src="https://github.com/ISA-tools/OntoMaton/blob/master/figures/ontomaton-fig8.png" width="700">

--- a/Settings-Template.html
+++ b/Settings-Template.html
@@ -85,6 +85,14 @@
             google.script.run.setOntologyInsertionPreference(insertionOneColumn);
         }
 
+        function updateCustomOLS3_API_BASE_URI() {
+            new_base_url = $('#option_CustomOLS3_API_BASE_URI').string();
+            console.log("new_base_url is set to:");
+            console.log(new_base_url);
+            google.script.run.setCustomOls3ApiBaseUri(new_base_url);
+        }
+
+
         function setOntologies(data) {
             ontologies = data;
             $('#loading').addClass('hidden');
@@ -157,10 +165,18 @@
         <br />
         <input type="radio" id="option_same_column" name="ontologyFormat" value="same"
             onchange="updateInsertionPreferences()">
-        <label for="male">Place term name and accession in same column</label><br>
+        <label for="option_same_column">Place term name and accession in same column</label><br>
         <input type="radio" id="option_different_column" name="ontologyFormat" onchange="updateInsertionPreferences()"
             value="different" checked>
-        <label for="female">Place term name and accession in different columns.</label><br>
+        <label for="option_different_column">Place term name and accession in different columns.</label><br>
+
+        <br /><br />
+        <p style="font-weight: bolder">Custom OLS3 API BASE_URI</p>
+        <br />
+        <input type="url" id="option_CustomOLS3_API_BASE_URI" name="CustomOLS3_API_BASE_URI"
+            onchange="updateCustomOLS3_API_BASE_URI()">
+        <label for="option_CustomOLS3_API_BASE_URI">OLS3 API base URI (w/o /search or /ontologies at end)</label><br>
+
     </div>
 
     <br /><br />

--- a/Settings.gs
+++ b/Settings.gs
@@ -147,7 +147,7 @@ function getBioPortalOntologies() {
 
 function getLinkedOpenVocabularies(){
 
-  var vocabsURL = "http://lov.okfn.org/dataset/lov/api/v2/vocabulary/list";
+  var vocabsURL = "https://lov.linkeddata.es/dataset/lov/api/v2/vocabulary/list";
   var cache = CacheService.getPrivateCache();
 
   if (cache.get("lov_fragments") == null) {

--- a/Utils.gs
+++ b/Utils.gs
@@ -32,6 +32,7 @@
 
 
 // constants
+var TIBOLS_API_BASE_URI = "https://service.tib.eu/ts4tib/api";
 var OLS_API_BASE_URI = "http://www.ebi.ac.uk/ols4/api";
 var OLS_PAGINATION_SIZE = 500; // MAX pagination size
 

--- a/Utils.gs
+++ b/Utils.gs
@@ -32,7 +32,7 @@
 
 
 // constants
-var OLS_API_BASE_URI = "http://www.ebi.ac.uk/ols/api";
+var OLS_API_BASE_URI = "http://www.ebi.ac.uk/ols4/api";
 var OLS_PAGINATION_SIZE = 500; // MAX pagination size
 
 /**

--- a/Utils.gs
+++ b/Utils.gs
@@ -35,6 +35,7 @@
 var TIBOLS_API_BASE_URI = "https://service.tib.eu/ts4tib/api";
 var OLS_API_BASE_URI = "http://www.ebi.ac.uk/ols4/api";
 var OLS_PAGINATION_SIZE = 500; // MAX pagination size
+var CUSTOMOLS3_API_BASE_URI = "https://service.tib.eu/ts4tib/api"; // replace with Settings sheet lookup
 
 /**
  * @description serializes an object to a queryString


### PR DESCRIPTION
Hi, 
this PR on top of #41 adds the option to search a custom OLS3 endpoint defined in the settings sheet. 
This serves two use case scenarios:
1) There might be OLS-based ontology services out there we don't know about, maybe catering to a small or even only internal user base. They can point OntoMaton to "their" OLS installation
2) The TIB Service has the notion of community-driven "collections" of ontologies, e.g. https://terminology.tib.eu/ts/ontologies?collection=NFDI4CULTURE, which are (will be) also available with the `collection` parameter in the API path, e.g. http://terminology.tib.eu/NFDI4CULTURE/api . To avoid that every collection needs its own search menue item, users can point OntoMaton to "their" collection via an entry in the `Settings` sheet. In theory, the functionality could also be achieved via restrictions against the entire TIB service, but those would have to be curated/maintained client-side, while the collections are community-maintained server-side. 
This PR also includes the open PRs #35, #37, #40 and #41 , we'll try to do some more testing and update once ready.
Yours,
Steffen 